### PR TITLE
Change byte count in tree_connect_andx_request

### DIFF
--- a/MS17_010/smb_exploit.py
+++ b/MS17_010/smb_exploit.py
@@ -211,7 +211,7 @@ def tree_connect_andx_request(ip, userid):
       '\x00\x00',          # AndXOffset
       '\x00\x00',          # Flags
       '\x01\x00',          # Password Length
-      '\x1C\x00',          # Byte Count
+      '\x1A\x00',          # Byte Count
       '\x00',              # Password
       ipc.encode(),        # \\xxx.xxx.xxx.xxx\IPC$
       '\x3f\x3f\x3f\x3f\x3f\x00'   # Service


### PR DESCRIPTION
I got this from comparing the packet capture from metasploit vs this python version.  With the previous version, it returned "Unable to detect if this host is vulnerable" more often for hosts, and this one will catch more of the vulnerable/unpatched hosts.